### PR TITLE
Use ReadOnlyBooleanProperty instead of ObservableValue<Boolean>

### DIFF
--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyBooleanProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyBooleanProperty.kt
@@ -36,7 +36,7 @@ class DirtyBooleanProperty(initialValue: Boolean): BooleanProperty(), DirtyPrope
         _isDirtyProperty.set(false)
     }
 
-    fun originalValueProperty(): ObservableValue<Boolean> = _originalValueProperty
+    fun originalValueProperty(): ReadOnlyBooleanProperty = _originalValueProperty
     val originalValue get() = _originalValueProperty.get()
 
     override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyBooleanProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyBooleanProperty.kt
@@ -3,6 +3,7 @@ package org.nield.dirtyfx.beans
 
 import javafx.beans.InvalidationListener
 import javafx.beans.property.BooleanProperty
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
@@ -38,7 +39,7 @@ class DirtyBooleanProperty(initialValue: Boolean): BooleanProperty(), DirtyPrope
     fun originalValueProperty(): ObservableValue<Boolean> = _originalValueProperty
     val originalValue get() = _originalValueProperty.get()
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun getName() = delegate.name

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyIntegerProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyIntegerProperty.kt
@@ -36,7 +36,7 @@ class DirtyIntegerProperty(initialValue: Int): IntegerProperty(), DirtyProperty{
         value = _originalValueProperty.get()
         _isDirtyProperty.set(false)
     }
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun getName() = delegate.name

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyListProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyListProperty.kt
@@ -41,7 +41,7 @@ class DirtyListProperty<T> constructor(originalList: List<T> = mutableListOf()):
 
     val originalList get() = FXCollections.unmodifiableObservableList(_originalList)
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun hashCode() = backingList.hashCode()

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyLongProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyLongProperty.kt
@@ -36,7 +36,7 @@ class DirtyLongProperty(initialValue: Long): LongProperty(), DirtyProperty {
         value = _originalValueProperty.get()
         _isDirtyProperty.set(false)
     }
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun getName() = delegate.name

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyMapProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyMapProperty.kt
@@ -37,7 +37,7 @@ class DirtyMapProperty<K,V> constructor(originalMap: Map<K,V>): DirtyProperty, M
 
     val originalMap get() = FXCollections.unmodifiableObservableMap(_originalMap)
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun hashCode() = backingMap.hashCode()

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyObjectProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyObjectProperty.kt
@@ -2,6 +2,7 @@ package org.nield.dirtyfx.beans
 
 
 import javafx.beans.property.Property
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.value.ChangeListener
@@ -34,6 +35,6 @@ class DirtyObjectProperty<T>(initialValue: T): Property<T> by SimpleObjectProper
         value = _originalValueProperty.get()
         _isDirtyProperty.set(false)
     }
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 }

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyReadOnlyWrapper.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyReadOnlyWrapper.kt
@@ -1,11 +1,12 @@
 package org.nield.dirtyfx.beans
 
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.ReadOnlyBooleanWrapper
 import org.nield.dirtyfx.tracking.DirtyProperty
 
 class DirtyReadOnlyWrapper(override val isDirty: Boolean): DirtyProperty {
 
-    override fun isDirtyProperty() = ReadOnlyBooleanWrapper(isDirty)
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = ReadOnlyBooleanWrapper(isDirty)
 
     override fun rebaseline() {
         // do nothing

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtySetProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtySetProperty.kt
@@ -45,7 +45,7 @@ class DirtySetProperty<T> constructor(originalSet: Set<T> = mutableSetOf()): Dir
 
     val originalSet get() = FXCollections.unmodifiableObservableSet(_originalSet)
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun hashCode() = backingSet.hashCode()

--- a/src/main/kotlin/org/nield/dirtyfx/beans/DirtyStringProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/beans/DirtyStringProperty.kt
@@ -1,6 +1,7 @@
 package org.nield.dirtyfx.beans
 
 import javafx.beans.InvalidationListener
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.StringProperty
 import javafx.beans.property.SimpleStringProperty
@@ -38,7 +39,7 @@ class DirtyStringProperty(initialValue: String): StringProperty(), DirtyProperty
         _isDirtyProperty.set(false)
     }
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun getName() = delegate.name

--- a/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableList.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableList.kt
@@ -1,8 +1,8 @@
 package org.nield.dirtyfx.collections
 
 
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
 import javafx.collections.ListChangeListener
 import javafx.collections.ObservableList
@@ -42,7 +42,7 @@ class DirtyObservableList<T> private constructor(_originalList: List<T> = listOf
 
     val originalList get() = FXCollections.unmodifiableObservableList(_originalList)
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun hashCode() = currentList.hashCode()

--- a/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableMap.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableMap.kt
@@ -1,7 +1,7 @@
 package org.nield.dirtyfx.collections
 
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
@@ -38,7 +38,7 @@ class DirtyObservableMap<K,V> private constructor(_originalMap: Map<K,V>,
 
     val originalMap get() = FXCollections.unmodifiableObservableMap(_originalMap)
 
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     override fun hashCode() = currentMap.hashCode()

--- a/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableSet.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/collections/DirtyObservableSet.kt
@@ -1,8 +1,7 @@
 package org.nield.dirtyfx.collections
 
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.value.ObservableValue
-import javafx.beans.value.WeakChangeListener
 import javafx.collections.FXCollections
 import javafx.collections.ObservableSet
 import javafx.collections.SetChangeListener
@@ -36,7 +35,7 @@ class DirtyObservableSet<T> private constructor(_originalSet: Set<T> = setOf(),
         addAll(_originalSet)
         _isDirtyProperty.set(false)
     }
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _isDirtyProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _isDirtyProperty
     override val isDirty get() = _isDirtyProperty.get()
 
     val originalSet get() = FXCollections.unmodifiableObservableSet(_originalSet)

--- a/src/main/kotlin/org/nield/dirtyfx/tracking/CompositeDirtyProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/tracking/CompositeDirtyProperty.kt
@@ -4,12 +4,11 @@ import javafx.beans.InvalidationListener
 import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.value.ChangeListener
-import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
 import javafx.collections.ListChangeListener
 import javafx.collections.WeakListChangeListener
 
-class CompositeDirtyProperty: DirtyProperty, ObservableValue<Boolean> {
+class CompositeDirtyProperty: ReadOnlyBooleanProperty(), DirtyProperty {
 
     private val items = FXCollections.observableArrayList<DirtyProperty> { arrayOf(it.isDirtyProperty()) }
     private val _dirtyStateProperty = SimpleBooleanProperty()
@@ -74,6 +73,12 @@ class CompositeDirtyProperty: DirtyProperty, ObservableValue<Boolean> {
     override fun addListener(listener: InvalidationListener?)  = _dirtyStateProperty.addListener(listener)
 
     override fun getValue() = _dirtyStateProperty.value
+
+    override fun get(): Boolean = _dirtyStateProperty.get()
+
+    override fun getName(): String = _dirtyStateProperty.name
+
+    override fun getBean(): Any = _dirtyStateProperty.bean
 
 
 }

--- a/src/main/kotlin/org/nield/dirtyfx/tracking/CompositeDirtyProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/tracking/CompositeDirtyProperty.kt
@@ -1,6 +1,7 @@
 package org.nield.dirtyfx.tracking
 
 import javafx.beans.InvalidationListener
+import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
@@ -26,7 +27,7 @@ class CompositeDirtyProperty: DirtyProperty, ObservableValue<Boolean> {
     /**
      * Indicates if any tracked DirtyProperties are dirty
      */
-    override fun isDirtyProperty(): ObservableValue<Boolean> = _dirtyStateProperty
+    override fun isDirtyProperty(): ReadOnlyBooleanProperty = _dirtyStateProperty
 
     /**
      * Indicates if any tracked DirtyProperties are dirty

--- a/src/main/kotlin/org/nield/dirtyfx/tracking/DirtyProperty.kt
+++ b/src/main/kotlin/org/nield/dirtyfx/tracking/DirtyProperty.kt
@@ -1,9 +1,9 @@
 package org.nield.dirtyfx.tracking
 
-import javafx.beans.value.ObservableValue
+import javafx.beans.property.ReadOnlyBooleanProperty
 
 interface DirtyProperty {
-    fun isDirtyProperty(): ObservableValue<Boolean>
+    fun isDirtyProperty(): ReadOnlyBooleanProperty
     val isDirty: Boolean
     fun rebaseline()
     fun reset()


### PR DESCRIPTION
First off, thanks for this library.

This PR modifies `DirtyProperty#isDirtyProperty()`, `DirtyBooleanProperty#originalValueProperty()` to return [ReadOnlyBooleanProperty](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/property/ReadOnlyBooleanProperty.html) instead of [ObservableValue<Boolean>](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/value/ObservableValue.html), and modifies `CompositeDirtyProperty` to extend [ReadOnlyBooleanProperty](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/property/ReadOnlyBooleanProperty.html) instead of [ObservableValue<Boolean>](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/value/ObservableValue.html).

The reason for this is that [ReadOnlyBooleanProperty](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/property/ReadOnlyBooleanProperty.html) has some useful utility methods, eg. [BooleanExpression#not()](https://docs.oracle.com/javase/8/javafx/api/javafx/beans/binding/BooleanExpression.html#not--).